### PR TITLE
Add gz-jetty-plugin alias packages

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -68,3 +68,19 @@ Description: Gazebo Plugin Library - Debugging symbols
  designed to rapidly develop robot applications.
  .
  Package contains debugging symbols
+
+Package: gz-jetty-plugin
+Depends: libgz-plugin4-dev (= ${binary:Version}), ${misc:Depends}
+Architecture: all
+Priority: optional
+Section: metapackages
+Description: alias package
+ Provides a package for Jetty without exposing the version number.
+
+Package: gz-jetty-plugin-cli
+Depends: gz-plugin4-cli (= ${binary:Version}), ${misc:Depends}
+Architecture: all
+Priority: optional
+Section: metapackages
+Description: alias package
+ Provides a package for Jetty without exposing the version number.


### PR DESCRIPTION
Adds gz-jetty-plugin and gz-jetty-plugin-cli packages that depend on libgz-plugin4-dev and gz-plugin4-cli respectively to allow installing Jetty packages without knowing the version number.

Part of https://github.com/gazebo-tooling/release-tools/issues/1326.