### PR TITLE
test: increase cmake version to 3.22.1

### DIFF
--- a/ubuntu/debian/tests/build
+++ b/ubuntu/debian/tests/build
@@ -10,7 +10,7 @@ WORKDIR=$(mktemp -d)
 cd $WORKDIR
 
 cat <<EOF > CMakeLists.txt
-cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 
 project(example)
 


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1503, similar to https://github.com/gazebo-release/gz-rotary-cmake-release/pull/2.